### PR TITLE
Add support for PowerPC-LE, 64-bit little-endian, Power9.

### DIFF
--- a/liblfds7.1.1/liblfds711/inc/liblfds711/lfds711_porting_abstraction_layer_processor.h
+++ b/liblfds7.1.1/liblfds711/inc/liblfds711/lfds711_porting_abstraction_layer_processor.h
@@ -102,11 +102,11 @@
   #define LFDS711_PAL_ATOMIC_ISOLATION_IN_BYTES   2048
 
 #endif
-  
-  
-  
-  
-  
+
+
+
+
+
 /****************************************************************************/
 #if( defined __GNUC__ && defined __arm__ )
 
@@ -350,7 +350,7 @@
 
 
 /****************************************************************************/
-#if( defined __GNUC__ && defined __ppc64__ )
+#if( defined __GNUC__ && ( defined __ppc64__ || defined __PPC64__ ) )
 
   #ifdef LFDS711_PAL_PROCESSOR
     #error More than one porting abstraction layer matches the current platform in "lfds711_porting_abstraction_layer_processor.h".
@@ -456,4 +456,3 @@
   #error No matching porting abstraction layer in "lfds711_porting_abstraction_layer_processor.h".
 
 #endif
-


### PR DESCRIPTION
Just passed the tests on an IBM Power9 CPU, Raptor Computing Blackbird motherboard, running Void Linux:

```
$ test/bin/test -r

Test Iteration 01
=================
Atomic add...passed
Atomic CAS...passed
Atomic exchange...passed
BTree (addonly, unbalanced) alignment...passed
BTree (addonly, unbalanced) adds and walking (fail on existing key)...passed
BTree (addonly, unbalanced) adds and walking (ovewrite on existing key)...passed
BTree (addonly, unbalanced) fail and overwrite on existing key...passed
Hash (addonly) alignment...passed
Hash (addonly) fail and overwrite...passed
Hash (addonly) random adds (fail on existing key)...passed
Hash (addonly) random adds (overwrite on existing key)...passed
Hash (addonly) iterate...passed
List (addonly, ordered, singlylinked) alignment...passed
List (addonly, ordered, singlylinked) new ordered...passed
List (addonly, ordered, singlylinked) new ordered with cursor...passed
List (addonly, singlylinked, unordered) alignment...passed
List (addonly, singlylinked, unordered) new start...passed
List (addonly, singlylinked, unordered) new end...passed
List (addonly, singlylinked, unordered) new after...passed
PRNG alignment...passed
PRNG generation...passed
Queue (bounded, many consumer, many producer) alignment...passed
Queue (bounded, many consumer, many producer) count...passed
Queue (bounded, many consumer, many producer) enqueuing...passed
Queue (bounded, many consumer, many producer) dequeuing...passed
Queue (bounded, many consumer, many producer) enqueuing and dequeuing...passed
Queue (bounded, many consumer, many producer) rapid enqueuing and dequeuing...passed
Queue (bounded, single producer, single consumer) dequeuing...passed
Queue (bounded, single producer, single consumer) enqueuing...passed
Queue (bounded, single producer, single consumer) enqueuing and dequeuing...passed
```